### PR TITLE
optimize LLAMA_CI_PATH, fix python package missing problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ openai_api_key.txt
 gpt4_custom_code_interpreter/
 tmp/
 gpt_data_gen/
+
+.vscode/

--- a/README.md
+++ b/README.md
@@ -55,24 +55,12 @@ cd Llama2-Code-Interpreter.git
 pip install -r requirements.txt
 ```
 
-I see, you want to include the part about setting the `LLAMA_CI_PATH` environment variable in the setup instructions. Here's how you might write it:
-
-### Setup
-
-**Set the `LLAMA_CI_PATH` environment variable:** This script requires the `LLAMA_CI_PATH` environment variable to be set to the directory that contains the relevant code. You can set it to the current directory like this:
-
-```bash
-export LLAMA_CI_PATH=$(pwd)
-```
-
-Please note that this setting is only valid for the current shell session. If you want to make it permanent, you can add it to your shell's startup file (like `.bashrc` or `.bash_profile`).
-
 ### Run App
 
 To start interacting with Llama2 via the Gradio UI:
 
 ```bash
-python3 chatbot.py --mode_path <your-model-path>
+python3 chatbot.py --model_path <your-model-path>
 ```
 
 Replace `<your-model-path>` with the path to the model file you want to use. (Usally I recommend you to use chat-type model e.g. `meta-llama/Llama-2-13b-chat`)

--- a/chatbot.py
+++ b/chatbot.py
@@ -1,13 +1,21 @@
+import os
+current_file_path = os.path.abspath(__file__)
+project_root_path = os.path.join(current_file_path, '..')
+project_root_path = os.path.abspath(project_root_path)
+os.environ["LLAMA_CI_PATH"] = current_file_path
+
 import gradio as gr
 import random
 import time
 import argparse
 
 from code_interpreter.LlamaCodeInterpreter import LlamaCodeInterpreter
-from code_interpreter.GPTCodeInterpreter import GPTCodeInterpreter
+# from code_interpreter.GPTCodeInterpreter import GPTCodeInterpreter
 from utils.const import *
 
 LLAMA2_MODEL_PATH = "./ckpt/llama-2-13b-chat"
+
+
 
 def load_model(model_path):
     print('++ Loading Model')

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@ retrying
 termcolor
 nbformat== 5.8.0
 nbconvert==7.7.1
+
+rich
+accelerate
+bitsandbytes


### PR DESCRIPTION
`LLAMA_CI_PATH` is now initialized once you launch `chatbot.py`, so users don't have to init `LLAMA_CI_PATH` manually.

When I run this project on my Mac, I encountered several issues of missing python package.
the flowing packages should be added into requirements.txt:
- rich
- accelerate
- bitsandbytes

Besides, I noticed that there is an error in your README.md: [click this link](https://github.com/SeungyounShin/Llama2-Code-Interpreter#run-app)
`--mode_path` should be `--model_path`

I think the best way to implement a code interpreter with Llama2, is to use `langchain` with its components. I am interested in doing such thing but did not find a proper git repo yet. If you are interested in doing so please let me know, Thanks!